### PR TITLE
Fixes failure when using API to test if already authorized

### DIFF
--- a/components/dropstore-ng/dropstore-ng.js
+++ b/components/dropstore-ng/dropstore-ng.js
@@ -54,7 +54,6 @@ angular.module("dropstore-ng", []).
                         deferred.reject(err)
                     } else {
                         logger.log('dropstore "'+cmdName+'" returned successfully', res);
-                        deferred.resolve(dropstoreDatastoreManager(res))
                     }
                 });
             }


### PR DESCRIPTION
If you use .authenticate({interactive: false}) to check if the user has already authorized your app, the code fails for the case where they were not authorized because it is successful in checking the state of authorization but there isn't a dropstoreDatamanager that can be returned because the user has not authorized the account.
